### PR TITLE
Updated Tagging entity

### DIFF
--- a/Entity/Tagging.php
+++ b/Entity/Tagging.php
@@ -22,7 +22,7 @@ class Tagging extends BaseTagging
     protected $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Kunstmaan\TaggingBundle\Entity\Tag")
+     * @ORM\ManyToOne(targetEntity="Kunstmaan\TaggingBundle\Entity\Tag", inversedBy="tagging")
      * @ORM\JoinColumn(name="tag_id", referencedColumnName="id", onDelete="CASCADE")
      */
     protected $tag;


### PR DESCRIPTION
Fixes invalid entity

```
The field Kunstmaan\TaggingBundle\Entity\Tag#tagging is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Kunstmaan\TaggingBundle\Entity\Tagging#tag does not contain the required 'inversedBy=tagging' attribute.
```
